### PR TITLE
Put start/end in URL hash so they can be linked to

### DIFF
--- a/public/rws.js
+++ b/public/rws.js
@@ -99,14 +99,17 @@ document.getElementById("go").addEventListener("click", function() {
     hide(document.getElementById("header"));
     show(document.getElementById("loading"));
     setTimeout(function() {
+        var data = {
+            start: ($("#start").val()==""?"David Hasselhoff":$("#start").val()),
+            stop: ($("#end").val()==""?"Eiffel Tower":$("#end").val())
+        };
+        /* save the endpoints in the url */
+        window.location.hash = $.param(data);
         $.ajax({
             url: "/api/findscale",
             //url: "data.txt",
             type: "GET",
-            data: {
-              start: ($("#start").val()==""?"David Hasselhoff":$("#start").val()),
-              stop: ($("#end").val()==""?"Eiffel Tower":$("#end").val())
-            },
+            data: data,
             dataType: "json",
             success: function(result) {
                 if (result.status > 2) { // success
@@ -158,3 +161,26 @@ document.getElementById("close_error").addEventListener("click", function() {
     hide(document.getElementById("error"));
     show(document.getElementById("header"));
 });
+
+/* https://gist.github.com/varemenos/2531765 */
+function getUrlVar(key){
+    var result = new RegExp(key + "=([^&]*)", "i").exec(window.location.hash);
+    return result && decodeURI(result[1].replace(/\+/g, ' ')) || "";
+}
+
+(function() {
+    /* pull parameters from url */
+    var start = getUrlVar("start");
+    var stop = getUrlVar("stop");
+
+    document.getElementById("start").value = start;
+    document.getElementById("end").value = stop;
+
+    /* if both are there then click the Go button */
+    if (start !== "" && stop !== "") {
+        /* wait a second to give a chance to peek at the endpoints */
+        setTimeout(function() {
+            document.getElementById("go").click();
+        }, 1000)
+    }
+})();


### PR DESCRIPTION
I thought this was really neat, except it was missing one thing... the ability to link interesting paths/scales to other people. So I added that.

Clicking 'Go' now puts the start and end values in the location hash.

When the page is opened, the values are pulled out of the hash and the inputs are set to the given values. If both start and end have values in the hash, then it waits 1 second and starts trying to find a path.

`+` in the hash are correctly converted back into spaces.
